### PR TITLE
fix: prevent focusing other WC when open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9260,11 +9260,6 @@
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
-    "inert-polyfill": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/inert-polyfill/-/inert-polyfill-0.2.5.tgz",
-      "integrity": "sha512-on1Nri2CciTI8hc+BaIGCe1pDO3Qzniivt9HALcse/NGvUvu/4t2uh6REwOU5fx/Nsb5c3dCRPJdvinYH0mlkg=="
-    },
     "infer-owner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -20048,6 +20043,11 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
+    },
+    "wicg-inert": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
+      "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A=="
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.0",
-    "inert-polyfill": "^0.2.5",
-    "lit-element": "^2.4.0"
+    "lit-element": "^2.4.0",
+    "wicg-inert": "^3.1.1"
   },
   "peerDependencies": {
     "@alaskaairux/orion-design-tokens": "^2.12.2",

--- a/src/component-base.js
+++ b/src/component-base.js
@@ -8,7 +8,8 @@ import { classMap } from 'lit-html/directives/class-map';
 
 // Import touch detection lib
 import "focus-visible/dist/focus-visible.min.js";
-import 'inert-polyfill/inert-polyfill.min.js';
+import 'wicg-inert';
+
 import styleCss from "./style-css.js";
 import styleCssFixed from './style-fixed-css.js';
 import styleUnformattedCssFixed from './style-unformatted-fixed-css.js';
@@ -117,7 +118,8 @@ export default class ComponentBase extends LitElement {
   closeDialog() {
     this.dispatchToggleEvent();
     this.cleanupInertNodes();
-    this.triggerElement.focus();
+    // Wait for the inert polyfill to react to the DOM change
+    Promise.resolve().then(() => { this.triggerElement.focus() } );
   }
 
   /**
@@ -181,8 +183,8 @@ export default class ComponentBase extends LitElement {
       html`` :
       html`
         <button class="dialog-header--action" id="dialog-close" @click="${this.handleCloseButtonClick}">
-          <div>${this.svg}</div>
-          <div class="util_displayHiddenVisually">Close</div>
+          <span>${this.svg}</span>
+          <span class="util_displayHiddenVisually">Close</span>
         </button>
       `
   }

--- a/test/auro-dialog.test.js
+++ b/test/auro-dialog.test.js
@@ -2,6 +2,7 @@ import { fixture, html, expect, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
 import '../src/auro-dialog.js';
 import '../src/auro-drawer.js';
+import './test-button.js';
 
 describe('auro-dialog', () => {
   it('auro-dialog is accessible', async () => {
@@ -178,6 +179,25 @@ describe('auro-drawer', () => {
     await sleep(100);
     expect(button.hasAttribute('inert')).to.be.false;
     expect(button.hasAttribute('aria-hidden')).to.be.false;
+  });
+
+  it('outside custom elements cannot be focused', async () => {
+    const el = await fixture(html`
+      <auro-dialog>
+        <span slot="header">It's a dialog</span>
+        <span slot="content">Hello World!</span>
+      </auro-dialog>
+      <test-button>Try to focus me</test-button>
+    `);
+
+    el.open = true;
+    await el.updated;
+    await sleep(100);
+
+    const button = document.querySelector('test-button');
+    button.focus();
+
+    expect(document.activeElement).to.not.equal(button);
   });
 
   it('dispatches toggle event on close', async () => {

--- a/test/test-button.js
+++ b/test/test-button.js
@@ -1,0 +1,19 @@
+import { LitElement, html } from 'lit-element';
+
+class TestButton extends LitElement {
+  focus() {
+    this.renderRoot.querySelector('button').focus();
+  }
+
+  render() {
+    return html`
+      <button>
+        <slot></slot>
+      </button>
+    `;
+  }
+}
+
+if (!customElements.get('test-button')) {
+  customElements.define('test-button', TestButton);
+}


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #8

## Summary:

This swaps out the inert polyfill we use for focus trapping. Google's polyfill was still allowing custom elements (e.g. auro-button) to be focused even when inert was applied. Using the WICG polyfill instead fixed that issue.

I linked my local package to the doc site and verified that you could no longer tab to other Auro elements on the page when the dialog was open.

This PR also fixes an issue where NVDA would not trigger the SVG close button due to divs being inside the button. This is not allowed, per the HTML spec.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
