### PR TITLE
add attribute stickyFooter to make the footer sticky

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -75,6 +75,68 @@ The `auro-dialog` and `auro-drawer` components should be used in situations wher
 ```
 </auro-accordion>
 
+Use the `stickyFooter` attribute to affix the footer action buttons to the lower part of the dialog window regardless of scroll position.
+<div class="exampleWrapper">
+  <auro-button onClick="toggleInterruption('#stickyFooterDialog')">Open Sticky Footer Dialog</auro-button>
+
+  <auro-dialog id="stickyFooterDialog" stickyFooter>
+    <span slot="header">Sticky Dialog</span>
+    <div slot="content">
+      <p>
+        When traveling on Alaska Airlines flights, Alaska Airlines checked baggage fees may apply. See <auro-hyperlink href="https://www.alaskaair.com/bagrules" target="_blank">alaskaair.com/bagrules</auro-hyperlink> for our rules. For itineraries that include other airlines, their checked baggage fees may apply, as displayed on their websites.
+      </p>
+      <p>
+        Baggage rules and fees will be based on the specific itinerary chosen. The applicable first and second bag fees will be displayed after you have added flights to the cart.
+      </p>
+      <auro-header level="3" display="500">
+        Before checking your bags, remember to:
+      </auro-header>
+      <ul>
+        <li>Caerphilly croque monsieur fondue</li>
+        <li>Taleggio goat mascarpone cow manchego cheese and wine emmental cheese strings</li>
+        <li>Cheddar cheese and biscuits chalk and cheese</li>
+        <li>Camembert de normandie stinking bishop bavarian bergkase</li>
+      </ul>
+    </div>
+    <div slot="footer" className="auro_containedButtons">
+      <auro-button secondary onClick="toggleInterruption('#stickyFooterDialog')">Close</auro-button>
+    </div>
+  </auro-dialog>
+</div>
+
+<auro-accordion lowProfile justifyRight>
+  <span slot="trigger">See code</span>
+
+```html
+<auro-button onClick="toggleInterruption('#stickyFooterDialog')">Open Sticky Footer Dialog</auro-button>
+
+<auro-dialog id="stickyFooterDialog">
+  <span slot="header">Sticky Dialog</span>
+  <div slot="content">
+    <p>
+      When traveling on Alaska Airlines flights, Alaska Airlines checked baggage fees may apply. See <auro-hyperlink href="https://www.alaskaair.com/bagrules" target="_blank">alaskaair.com/bagrules</auro-hyperlink> for our rules. For itineraries that include other airlines, their checked baggage fees may apply, as displayed on their websites.
+    </p>
+    <p>
+      Baggage rules and fees will be based on the specific itinerary chosen. The applicable first and second bag fees will be displayed after you have added flights to the cart.
+    </p>
+    <auro-header level="3" display="500">
+      Before checking your bags, remember to:
+    </auro-header>
+    <ul>
+      <li>Caerphilly croque monsieur fondue</li>
+      <li>Taleggio goat mascarpone cow manchego cheese and wine emmental cheese strings</li>
+      <li>Cheddar cheese and biscuits chalk and cheese</li>
+      <li>Camembert de normandie stinking bishop bavarian bergkase</li>
+    </ul>
+  </div>
+  <div slot="footer" className="auro_containedButtons">
+    <auro-button secondary onClick="toggleInterruption('#stickyFooterDialog')">Close</auro-button>
+  </div>
+</auro-dialog>
+```
+</auro-accordion>
+
+
 Read the [auro-dialog](https://auro.alaskaair.com/components/auro/interruption/dialog) documentation for detailed instructions on implementations.
 
 ## Drawer example

--- a/demo/dialog.html
+++ b/demo/dialog.html
@@ -28,7 +28,7 @@
     <main></main>
 
     <script type="module">
-      import 'https://unpkg.com/marked@latest/marked.min.js';
+      import 'https://unpkg.com/marked@3.0.8/marked.min.js';
       import 'https://unpkg.com/prismjs@latest/prism.js';
       fetch('/demo/dialog.md')
         .then((response) => response.text())

--- a/demo/dialog.md
+++ b/demo/dialog.md
@@ -55,6 +55,68 @@ The structure of the dialog itself consists of three slots. The `header`, `conte
 
 It should be noted that the `footer` slot is reserved for the placement of action buttons.
 
+### Sticky footer
+
+Use the `stickyFooter` attribute to affix the footer action buttons to the lower part of the dialog window regardless of scroll position.
+
+<div class="demo--inline exampleWrapper auro_containedButtons">
+  <auro-button onClick="toggleInterruption('#stickyFooterDialog')">Open Sticky Footer Dialog</auro-button>
+</div>
+
+<auro-dialog id="stickyFooterDialog" stickyFooter>
+  <span slot="header">Sticky Footer Dialog</span>
+  <div slot="content">
+    <p>
+      When traveling on Alaska Airlines flights, Alaska Airlines checked baggage fees may apply. See <auro-hyperlink href="https://www.alaskaair.com/bagrules" target="_blank">alaskaair.com/bagrules</auro-hyperlink> for our rules. For itineraries that include other airlines, their checked baggage fees may apply, as displayed on their websites.
+    </p>
+    <p>
+      Baggage rules and fees will be based on the specific itinerary chosen. The applicable first and second bag fees will be displayed after you have added flights to the cart.
+    </p>
+    <auro-header level="3" display="500">
+      Before checking your bags, remember to:
+    </auro-header>
+    <ul>
+      <li>Caerphilly croque monsieur fondue</li>
+      <li>Taleggio goat mascarpone cow manchego cheese and wine emmental cheese strings</li>
+      <li>Cheddar cheese and biscuits chalk and cheese</li>
+      <li>Camembert de normandie stinking bishop bavarian bergkase</li>
+    </ul>
+  </div>
+  <div slot="footer" className="auro_containedButtons">
+    <auro-button secondary onClick="toggleInterruption('#stickyFooterDialog')">Close</auro-button>
+  </div>
+</auro-dialog>
+
+<auro-accordion lowProfile justifyRight>
+  <span slot="trigger">See code</span>
+
+```html
+<auro-dialog id="stickyFooterDialog" stickyFooter>
+  <span slot="header">Sticky Footer Dialog</span>
+  <div slot="content">
+    <p>
+      When traveling on Alaska Airlines flights, Alaska Airlines checked baggage fees may apply. See <auro-hyperlink href="https://www.alaskaair.com/bagrules" target="_blank">alaskaair.com/bagrules</auro-hyperlink> for our rules. For itineraries that include other airlines, their checked baggage fees may apply, as displayed on their websites.
+    </p>
+    <p>
+      Baggage rules and fees will be based on the specific itinerary chosen. The applicable first and second bag fees will be displayed after you have added flights to the cart.
+    </p>
+    <auro-header level="3" display="500">
+      Before checking your bags, remember to:
+    </auro-header>
+    <ul>
+      <li>Caerphilly croque monsieur fondue</li>
+      <li>Taleggio goat mascarpone cow manchego cheese and wine emmental cheese strings</li>
+      <li>Cheddar cheese and biscuits chalk and cheese</li>
+      <li>Camembert de normandie stinking bishop bavarian bergkase</li>
+    </ul>
+  </div>
+  <div slot="footer" className="auro_containedButtons">
+    <auro-button secondary onClick="toggleInterruption('#stickyFooterDialog')">Close</auro-button>
+  </div>
+</auro-dialog>
+```
+</auro-accordion>
+
 ## Dialog size options (sm, md, default)
 
 The auro-dialog supports three different sizes. A default dialog is equal to the large size dialog. Using the `sm` and `md` attributes, the component supports these sizes for both mobile and desktop.

--- a/demo/drawer.html
+++ b/demo/drawer.html
@@ -28,7 +28,7 @@
     <main></main>
 
     <script type="module">
-      import 'https://unpkg.com/marked@latest/marked.min.js';
+      import 'https://unpkg.com/marked@3.0.8/marked.min.js';
       import 'https://unpkg.com/prismjs@latest/prism.js';
       fetch('/demo/drawer.md')
         .then((response) => response.text())

--- a/demo/index.html
+++ b/demo/index.html
@@ -28,7 +28,7 @@
     <main></main>
 
     <script type="module">
-      import 'https://unpkg.com/marked@latest/marked.min.js';
+      import 'https://unpkg.com/marked@3.0.8/marked.min.js';
       import 'https://unpkg.com/prismjs@latest/prism.js';
       fetch('/demo/demo.md')
         .then((response) => response.text())

--- a/src/style.scss
+++ b/src/style.scss
@@ -229,6 +229,19 @@ $auro-spacing-options: none;
   }
 }
 
+:host([stickyFooter]) {
+  .dialog {
+    padding-bottom: 0;
+  }
+
+  .dialog-footer {
+    position: sticky;
+    bottom: 0;
+    background-color: var(--auro-color-base-white);
+    padding: var(--auro-size-sm) 0 var(--auro-size-sm) 0;
+  }
+}
+
 :host([sm][lg]),
 :host([md][lg]) {
   @include auro_breakpoint--md {


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** # (issue, if applicable)

## Summary:
If the height of the browser window is small, the user will have to scroll to the bottom of the modal to see the footer's content. If footer's content is very important, it could lead to lost revenue. Set the attribute "stickyFooter" to have the footer's content always visible, by making the footer sticky.

Fixes https://github.com/AlaskaAirlines/auro-interruption/issues/57

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

## Type of change:

- [x] New capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
